### PR TITLE
Add AccountService skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+*.user
+*.suo
+*.DS_Store
+.env

--- a/AccountService/Dockerfile
+++ b/AccountService/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore ./src/AccountService.API/AccountService.API.csproj
+RUN dotnet publish ./src/AccountService.API/AccountService.API.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "AccountService.API.dll"]

--- a/AccountService/src/AccountService.API/AccountService.API.csproj
+++ b/AccountService/src/AccountService.API/AccountService.API.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../AccountService.Application/AccountService.Application.csproj" />
+    <ProjectReference Include="../AccountService.Infrastructure/AccountService.Infrastructure.csproj" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/AccountService/src/AccountService.API/Controllers/AccountsController.cs
+++ b/AccountService/src/AccountService.API/Controllers/AccountsController.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AccountService.Application.DTOs;
+using AccountService.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AccountService.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AccountsController : ControllerBase
+    {
+        private readonly IAccountService _service;
+
+        public AccountsController(IAccountService service)
+        {
+            _service = service;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<AccountDto>> Create(AccountDto dto)
+        {
+            var created = await _service.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpGet("{id:guid}")]
+        public async Task<ActionResult<AccountDto>> GetById(Guid id)
+        {
+            var account = await _service.GetAsync(id);
+            if (account == null) return NotFound();
+            return Ok(account);
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<List<AccountDto>>> Search([FromQuery]string ownerName = "")
+        {
+            var result = await _service.SearchAsync(ownerName);
+            return Ok(result);
+        }
+
+        [HttpPut("{id:guid}")]
+        public async Task<IActionResult> Update(Guid id, AccountDto dto)
+        {
+            if (id != dto.Id) return BadRequest();
+            await _service.UpdateAsync(dto);
+            return NoContent();
+        }
+
+        [HttpDelete("{id:guid}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            await _service.DeleteAsync(id);
+            return NoContent();
+        }
+    }
+}

--- a/AccountService/src/AccountService.API/Program.cs
+++ b/AccountService/src/AccountService.API/Program.cs
@@ -1,0 +1,28 @@
+using AccountService.Application.Interfaces;
+using AccountService.Application.Services;
+using AccountService.Infrastructure;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddScoped<IAccountService, AccountService.Application.Services.AccountService>();
+builder.Services.AddInfrastructure(builder.Configuration);
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/AccountService/src/AccountService.API/appsettings.json
+++ b/AccountService/src/AccountService.API/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=sqlserver;Database=AccountDb;User=sa;Password=Your_password123;"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/AccountService/src/AccountService.Application/AccountService.Application.csproj
+++ b/AccountService/src/AccountService.Application/AccountService.Application.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../AccountService.Domain/AccountService.Domain.csproj" />
+    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="MediatR" Version="11.1.0" />
+  </ItemGroup>
+</Project>

--- a/AccountService/src/AccountService.Application/DTOs/AccountDto.cs
+++ b/AccountService/src/AccountService.Application/DTOs/AccountDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace AccountService.Application.DTOs
+{
+    public class AccountDto
+    {
+        public Guid Id { get; set; }
+        public string OwnerName { get; set; } = string.Empty;
+        public string Currency { get; set; } = string.Empty;
+        public decimal Balance { get; set; }
+    }
+}

--- a/AccountService/src/AccountService.Application/Interfaces/IAccountService.cs
+++ b/AccountService/src/AccountService.Application/Interfaces/IAccountService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AccountService.Application.DTOs;
+
+namespace AccountService.Application.Interfaces
+{
+    public interface IAccountService
+    {
+        Task<AccountDto> CreateAsync(AccountDto account);
+        Task<AccountDto?> GetAsync(Guid id);
+        Task<List<AccountDto>> SearchAsync(string ownerName);
+        Task UpdateAsync(AccountDto account);
+        Task DeleteAsync(Guid id);
+    }
+}

--- a/AccountService/src/AccountService.Application/Services/AccountService.cs
+++ b/AccountService/src/AccountService.Application/Services/AccountService.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AccountService.Application.DTOs;
+using AccountService.Application.Interfaces;
+using AccountService.Domain.Entities;
+using AccountService.Domain.Interfaces;
+
+namespace AccountService.Application.Services
+{
+    public class AccountService : IAccountService
+    {
+        private readonly IAccountRepository _repo;
+
+        public AccountService(IAccountRepository repo)
+        {
+            _repo = repo;
+        }
+
+        public async Task<AccountDto> CreateAsync(AccountDto accountDto)
+        {
+            var entity = new Account
+            {
+                Id = Guid.NewGuid(),
+                OwnerName = accountDto.OwnerName,
+                Currency = accountDto.Currency,
+                Balance = accountDto.Balance,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await _repo.AddAsync(entity);
+
+            accountDto.Id = entity.Id;
+            return accountDto;
+        }
+
+        public async Task<AccountDto?> GetAsync(Guid id)
+        {
+            var entity = await _repo.GetByIdAsync(id);
+            if (entity == null) return null;
+            return new AccountDto
+            {
+                Id = entity.Id,
+                OwnerName = entity.OwnerName,
+                Currency = entity.Currency,
+                Balance = entity.Balance
+            };
+        }
+
+        public async Task<List<AccountDto>> SearchAsync(string ownerName)
+        {
+            var accounts = await _repo.SearchAsync(ownerName);
+            var list = new List<AccountDto>();
+            foreach (var acc in accounts)
+            {
+                list.Add(new AccountDto
+                {
+                    Id = acc.Id,
+                    OwnerName = acc.OwnerName,
+                    Currency = acc.Currency,
+                    Balance = acc.Balance
+                });
+            }
+            return list;
+        }
+
+        public async Task UpdateAsync(AccountDto account)
+        {
+            var entity = await _repo.GetByIdAsync(account.Id);
+            if (entity == null) return;
+            entity.OwnerName = account.OwnerName;
+            entity.Currency = account.Currency;
+            entity.Balance = account.Balance;
+            await _repo.UpdateAsync(entity);
+        }
+
+        public Task DeleteAsync(Guid id) => _repo.DeleteAsync(id);
+    }
+}

--- a/AccountService/src/AccountService.Domain/AccountService.Domain.csproj
+++ b/AccountService/src/AccountService.Domain/AccountService.Domain.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/AccountService/src/AccountService.Domain/Entities/Account.cs
+++ b/AccountService/src/AccountService.Domain/Entities/Account.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace AccountService.Domain.Entities
+{
+    public class Account
+    {
+        public Guid Id { get; set; }
+        public string OwnerName { get; set; } = string.Empty;
+        public string Currency { get; set; } = string.Empty;
+        public decimal Balance { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/AccountService/src/AccountService.Domain/Enums/Currency.cs
+++ b/AccountService/src/AccountService.Domain/Enums/Currency.cs
@@ -1,0 +1,9 @@
+namespace AccountService.Domain.Enums
+{
+    public enum Currency
+    {
+        USD,
+        EUR,
+        RWF
+    }
+}

--- a/AccountService/src/AccountService.Domain/Interfaces/IAccountRepository.cs
+++ b/AccountService/src/AccountService.Domain/Interfaces/IAccountRepository.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AccountService.Domain.Entities;
+
+namespace AccountService.Domain.Interfaces
+{
+    public interface IAccountRepository
+    {
+        Task<Account?> GetByIdAsync(Guid id);
+        Task<List<Account>> SearchAsync(string ownerName);
+        Task AddAsync(Account account);
+        Task UpdateAsync(Account account);
+        Task DeleteAsync(Guid id);
+    }
+}

--- a/AccountService/src/AccountService.Infrastructure/AccountService.Infrastructure.csproj
+++ b/AccountService/src/AccountService.Infrastructure/AccountService.Infrastructure.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../AccountService.Domain/AccountService.Domain.csproj" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/AccountService/src/AccountService.Infrastructure/Data/AccountDbContext.cs
+++ b/AccountService/src/AccountService.Infrastructure/Data/AccountDbContext.cs
@@ -1,0 +1,28 @@
+using AccountService.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace AccountService.Infrastructure.Data
+{
+    public class AccountDbContext : DbContext
+    {
+        public AccountDbContext(DbContextOptions<AccountDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Account> Accounts => Set<Account>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Account>(entity =>
+            {
+                entity.ToTable("Accounts");
+                entity.HasKey(a => a.Id);
+                entity.Property(a => a.OwnerName).IsRequired();
+                entity.Property(a => a.Currency).IsRequired();
+                entity.Property(a => a.Balance).HasColumnType("decimal(18,2)");
+                entity.Property(a => a.CreatedAt);
+            });
+        }
+    }
+}

--- a/AccountService/src/AccountService.Infrastructure/DependencyInjection.cs
+++ b/AccountService/src/AccountService.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,22 @@
+using AccountService.Domain.Interfaces;
+using AccountService.Infrastructure.Data;
+using AccountService.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AccountService.Infrastructure
+{
+    public static class DependencyInjection
+    {
+        public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration config)
+        {
+            services.AddDbContext<AccountDbContext>(options =>
+                options.UseSqlServer(config.GetConnectionString("DefaultConnection")));
+
+            services.AddScoped<IAccountRepository, AccountRepository>();
+
+            return services;
+        }
+    }
+}

--- a/AccountService/src/AccountService.Infrastructure/Repositories/AccountRepository.cs
+++ b/AccountService/src/AccountService.Infrastructure/Repositories/AccountRepository.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AccountService.Domain.Entities;
+using AccountService.Domain.Interfaces;
+using AccountService.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace AccountService.Infrastructure.Repositories
+{
+    public class AccountRepository : IAccountRepository
+    {
+        private readonly AccountDbContext _db;
+
+        public AccountRepository(AccountDbContext db)
+        {
+            _db = db;
+        }
+
+        public async Task AddAsync(Account account)
+        {
+            _db.Accounts.Add(account);
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            var entity = await _db.Accounts.FindAsync(id);
+            if (entity == null) return;
+            _db.Accounts.Remove(entity);
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task<Account?> GetByIdAsync(Guid id) =>
+            await _db.Accounts.AsNoTracking().FirstOrDefaultAsync(a => a.Id == id);
+
+        public async Task<List<Account>> SearchAsync(string ownerName)
+        {
+            return await _db.Accounts.AsNoTracking()
+                .Where(a => a.OwnerName.Contains(ownerName))
+                .ToListAsync();
+        }
+
+        public async Task UpdateAsync(Account account)
+        {
+            _db.Accounts.Update(account);
+            await _db.SaveChangesAsync();
+        }
+    }
+}

--- a/AccountService/tests/AccountService.Tests/AccountService.Tests.csproj
+++ b/AccountService/tests/AccountService.Tests/AccountService.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <ProjectReference Include="../../src/AccountService.Application/AccountService.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/AccountService/tests/AccountService.Tests/AccountServiceTests.cs
+++ b/AccountService/tests/AccountService.Tests/AccountServiceTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading.Tasks;
+using AccountService.Application.DTOs;
+using AccountService.Application.Services;
+using AccountService.Domain.Entities;
+using AccountService.Domain.Interfaces;
+using Moq;
+using Xunit;
+
+namespace AccountService.Tests
+{
+    public class AccountServiceTests
+    {
+        [Fact]
+        public async Task CreateAsync_ShouldReturnCreatedAccount()
+        {
+            var repo = new Mock<IAccountRepository>();
+            repo.Setup(r => r.AddAsync(It.IsAny<Account>())).Returns(Task.CompletedTask);
+
+            var service = new AccountService.Application.Services.AccountService(repo.Object);
+            var dto = new AccountDto
+            {
+                OwnerName = "John Doe",
+                Currency = "USD",
+                Balance = 100m
+            };
+
+            var result = await service.CreateAsync(dto);
+
+            Assert.NotEqual(Guid.Empty, result.Id);
+            Assert.Equal("John Doe", result.OwnerName);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # fintech-app-simulator
-Simulated fintech app that allows KYC, account management, funds transfer, and transaction history — mimicking a core banking microservice.
+
+This repository contains a simplified core banking simulation built in a modular way. Services are added gradually following Clean Architecture principles.
+
+## AccountService
+
+The first module provides a basic account management REST API implemented with **.NET 7** and **Entity Framework Core** targeting SQL Server. It exposes CRUD endpoints for accounts in multiple currencies (USD, EUR, RWF).
+
+### Running locally
+
+Docker is used for local development. Build and start the API together with a SQL Server instance:
+
+```bash
+docker-compose up --build
+```
+
+The API will be available on `http://localhost:5000` with Swagger UI at `/swagger`.
+
+### Project structure
+
+- `AccountService/src` – service implementation following Clean Architecture
+- `AccountService/tests` – xUnit tests
+
+More services (KYC, Transactions, etc.) will be added in future iterations.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+services:
+  accountservice:
+    build:
+      context: ./AccountService
+      dockerfile: Dockerfile
+    ports:
+      - "5000:80"
+    depends_on:
+      - sqlserver
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+    networks:
+      - backend
+
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      SA_PASSWORD: "Your_password123"
+      ACCEPT_EULA: "Y"
+    ports:
+      - "1433:1433"
+    networks:
+      - backend
+
+networks:
+  backend:
+    driver: bridge


### PR DESCRIPTION
## Summary
- set up AccountService with Clean Architecture
- add CRUD controller and EF Core context
- provide Dockerfile and docker-compose for SQL Server
- document setup in README
- include sample xUnit test

## Testing
- `dotnet test AccountService/tests/AccountService.Tests/AccountService.Tests.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517021594c832e8a0fba4aa0394051